### PR TITLE
utils/throttle: Typing updates

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,18 +1,17 @@
 export function throttle<T extends (...args: any[]) => void>(
   func: T,
-  threshold: number = 250,
-  scope?: any
+  threshold = 250,
+  scope?: unknown
 ): T {
   let last: number, deferTimer: number;
-  return function(this: any) {
-    let context = scope || this;
+  return function (this: any, ...args: any) {
+    const context: unknown = scope || this;
 
-    let now = Date.now(),
-      args = arguments;
+    const now = Date.now();
     if (last && now < last + threshold) {
       // hold on to it
       clearTimeout(deferTimer);
-      deferTimer = setTimeout(function() {
+      deferTimer = window.setTimeout(function () {
         last = now;
         func.apply(context, args);
       }, threshold);


### PR DESCRIPTION
I ported this function to a project of mine and these are the corrections I needed to build in TS 4.0 (note it probably works in earlier versions)

`window.setTimeout` makes sure that `threshhold`'s typing isn't confused with node's `setTimeout`.  `threshhold` in `window.setTimeout` wants a number (apparently).